### PR TITLE
Fix warning messages

### DIFF
--- a/src/components/BloggerPosts.jsx
+++ b/src/components/BloggerPosts.jsx
@@ -26,9 +26,9 @@ export default class BloggerPosts extends Component {
 
   renderBlogPosts = () => {
     const { bloggerPosts } = this.state;
-    return bloggerPosts.map(post => {
+    return bloggerPosts.map((post, index) => {
       return (
-        <div>
+        <div key={index}>
           <BlogPostContainer>
             <h3>
               {ReactHtmlParser(post.title)}

--- a/src/components/styles/Footer.js
+++ b/src/components/styles/Footer.js
@@ -34,7 +34,7 @@ export const FooterLink = styled.a`
   ${FooterLinkStyle};
 `;
 
-export const FooterRouterLink = styled(Link).attrs({to: props => props.to})`
+export const FooterRouterLink = styled(Link).attrs(props => ({to: props.to}))`
   ${FooterLinkStyle};
 `;
 

--- a/src/components/styles/HeaderBar.js
+++ b/src/components/styles/HeaderBar.js
@@ -6,15 +6,15 @@ export const StyledHeaderBar = styled.div`
   display: flex;
   text-align: left;
   border: solid 1px ${COLOURS.GUNMETAL_GREY};
-  padding-left: 50px;
   background-color: ${COLOURS.GUNMETAL_GREY};
   color: white;
 `;
 
 export const HeaderBarRouterLink = styled(Link).attrs({to: props => props.to})`
   :not(.MsoFollowed) {
-    width: 350px;
-    min-width: 300px;
+    width: 290px;
+    min-width: 290px;
+    padding: 0 50px;
     text-decoration: none;
     color: inherit;
   }

--- a/src/components/styles/HeaderBar.js
+++ b/src/components/styles/HeaderBar.js
@@ -10,7 +10,7 @@ export const StyledHeaderBar = styled.div`
   color: white;
 `;
 
-export const HeaderBarRouterLink = styled(Link).attrs({to: props => props.to})`
+export const HeaderBarRouterLink = styled(Link).attrs(props => ({to: props.to}))`
   :not(.MsoFollowed) {
     width: 290px;
     min-width: 290px;

--- a/src/components/styles/Navbar.js
+++ b/src/components/styles/Navbar.js
@@ -20,6 +20,7 @@ export const NavbarLinks = styled.div`
 export const NavbarLinksList = styled.ul`
   height: 100%;
   margin: 0;
+  padding: 0;
   display: flex;
 `;
 

--- a/src/components/styles/Navbar.js
+++ b/src/components/styles/Navbar.js
@@ -24,7 +24,7 @@ export const NavbarLinksList = styled.ul`
   display: flex;
 `;
 
-export const NavbarLink = styled(NavLink).attrs({to: props => props.to})`
+export const NavbarLink = styled(NavLink).attrs(props => ({to: props.to}))`
   :not(.MsoHyperlink) {
     padding: 25px;
     text-decoration: none;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,5 @@
 import React from "react";
 
 export const generateParagraphs = content => {
-  return content.map(sentence => <p>{sentence}</p>);
+  return content.map((sentence, index) => <p key={index}>{sentence}</p>);
 };


### PR DESCRIPTION
1) Fix positioning of elements in the Header and NavBar so that they are displayed properly
2) Fix error messages appearing in Console.
N.B. Warnings re unrecognised `<o:p>` element can be ignored - they are harmless and just relate to Word's crappy HTML formatting.